### PR TITLE
Remove extraneous backslash from docs

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -54,8 +54,8 @@ Examples of equivalent ways to group instructions:
 
 - `a(b}c` <-> `{a(b)}c`
 - `a(b}c)d` <-> `({a(b)}c)d`
-- ``(a{b}c\`d`` <-> `((a{b}c)d)`
-- ``a{b|cd\`e\`f}`` <-> `a{b|((cd)e)f}`
+- ``(a{b}c`d`` <-> `((a{b}c)d)`
+- ``a{b|cd`e`f}`` <-> `a{b|((cd)e)f}`
 
 
 ###Assertions


### PR DESCRIPTION
I think those were superfluous, due to the double backtick syntax of markdown.
